### PR TITLE
Responsiveness

### DIFF
--- a/app/assets/stylesheets/components/_parallax.scss
+++ b/app/assets/stylesheets/components/_parallax.scss
@@ -69,7 +69,7 @@ html {
   border-radius: 5px;
 }
 
-@media only screen and (max-width: 920px) {
+@media only screen and (max-width: 1440px) {
   .bgimg1, .bgimg2, .bgimg3 {
     background-attachment: scroll;
   }

--- a/app/assets/stylesheets/components/_signup-home.scss
+++ b/app/assets/stylesheets/components/_signup-home.scss
@@ -71,8 +71,12 @@
   border-radius: 5px;
 }
 
-@media only screen and (max-width: 1024px) {
+@media only screen and (max-width: 1440px) {
   .outer-box-form-home {
+    height: unset;
+    min-height: fit-content;
+  }
+  .signin-box {
     height: unset;
     min-height: fit-content;
   }


### PR DESCRIPTION
Had to turn off the parallax for screens smaller than 1440px, or the sign-in form was cut when the next image started.